### PR TITLE
In docs there was wrong namespace address

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -11,11 +11,11 @@
 composer require contributte/latte-parsedown-extra
 ```
 
-## Configuration 
+## Configuration
 
 ```yaml
 extensions:
-    parsedown: Contributte\ParsedownExtra\DI\ParsedownExtraExtension
+    parsedown: Contributte\Parsedown\DI\ParsedownExtraExtension
 
 parsedown:
     helper: parsedown # Name of the helper in Latte


### PR DESCRIPTION
In original docs, the implementations via config.neon, extensions: .... caused DI creation failure. This is easier fix than renaming all namespaces in source to right one, and there is no point of doing it, while the extension works fine now...