### PR TITLE
Add standalone mode support

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -3,8 +3,9 @@
 ## Content
 
 - [Installation - how to install](#installation)
-- [Extension - how to configure](#configuration)
+- [Configuration - how to configure](#configuration)
 - [Usage - how to use](#usage)
+- [Usage - standalone](#standalone-usage)
 
 ## Installation
 
@@ -34,4 +35,22 @@ parsedown:
 This is my text!
 
 {/block}
+```
+
+## Standalone usage
+
+Use the `ParsedownExtension` to register the filter directly with Latte (without Nette DI):
+
+```php
+use Contributte\Parsedown\ParsedownExtension;
+use Latte\Engine;
+
+$latte = new Engine();
+$latte->addExtension(new ParsedownExtension());
+```
+
+You can customize the filter name:
+
+```php
+$latte->addExtension(new ParsedownExtension(filterName: 'markdown'));
 ```

--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -15,4 +15,4 @@ jobs:
     name: "Codesniffer"
     uses: contributte/.github/.github/workflows/codesniffer.yml@master
     with:
-      php: "8.2"
+      php: "8.3"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,4 +15,4 @@ jobs:
     name: "Phpstan"
     uses: contributte/.github/.github/workflows/phpstan.yml@master
     with:
-      php: "8.2"
+      php: "8.3"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,12 @@ on:
     - cron: "0 8 * * 1"
 
 jobs:
+  test84:
+    name: "Nette Tester"
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
+    with:
+      php: "8.4"
+
   test83:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester.yml@master
@@ -23,15 +29,9 @@ jobs:
     with:
       php: "8.2"
 
-  test81:
-    name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@master
-    with:
-      php: "8.1"
-
   testlower:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester.yml@master
     with:
-      php: "8.1"
+      php: "8.2"
       composer: "composer update --no-interaction --no-progress --prefer-dist --prefer-stable --prefer-lowest"

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,26 @@
-.PHONY: install
+.PHONY: install qa cs csf phpstan tests coverage
+
 install:
 	composer update
 
-.PHONY: qa
 qa: phpstan cs
 
-.PHONY: cs
 cs:
 ifdef GITHUB_ACTION
-	vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --extensions="php,phpt" --colors -nsp -q --report=checkstyle src tests | cs2pr
+	vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --colors -nsp --extensions=php,phpt -q --report=checkstyle src tests | cs2pr
 else
-	vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --extensions="php,phpt" --colors -nsp src tests
+	vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --colors -nsp --extensions=php,phpt src tests
 endif
 
-.PHONY: csf
 csf:
-	vendor/bin/phpcbf --standard=ruleset.xml --encoding=utf-8 --extensions="php,phpt" --colors -nsp src tests
+	vendor/bin/phpcbf --standard=ruleset.xml --encoding=utf-8 --colors -nsp --extensions=php,phpt src tests
 
-.PHONY: phpstan
 phpstan:
 	vendor/bin/phpstan analyse -c phpstan.neon
 
-.PHONY: tests
 tests:
 	vendor/bin/tester -s -p php --colors 1 -C tests/Cases
 
-.PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
 	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "erusev/parsedown": "^1.7.4",
     "erusev/parsedown-extra": "^0.8.1",
     "latte/latte": "^3.0.12",
@@ -21,7 +21,7 @@
   "require-dev": {
     "contributte/qa": "^0.4",
     "contributte/tester": "^0.4",
-    "contributte/phpstan": "^0.1",
+    "contributte/phpstan": "^0.2.0",
     "nette/application": "^3.1.14"
   },
   "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
 
 parameters:
 	level: 9
-	phpVersion: 80100
+	phpVersion: 80200
 
 	scanDirectories:
 		- src
@@ -14,5 +14,3 @@ parameters:
 	paths:
 		- src
 		- .docs
-
-	ignoreErrors:

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Contributte" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<!-- Rulesets -->
-	<rule ref="./vendor/contributte/qa/ruleset-8.0.xml"/>
+	<rule ref="./vendor/contributte/qa/ruleset-8.2.xml"/>
 
 	<!-- Rules -->
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">

--- a/src/ParsedownExtension.php
+++ b/src/ParsedownExtension.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Parsedown;
+
+use Latte\Extension;
+
+class ParsedownExtension extends Extension
+{
+
+	private ParsedownExtraAdapter $adapter;
+
+	private string $filterName;
+
+	public function __construct(?ParsedownExtraAdapter $adapter = null, string $filterName = 'parsedown')
+	{
+		$this->adapter = $adapter ?? new ParsedownExtraAdapter();
+		$this->filterName = $filterName;
+	}
+
+	/**
+	 * @return array<string, callable>
+	 */
+	public function getFilters(): array
+	{
+		$filter = new ParsedownFilter($this->adapter);
+
+		return [
+			$this->filterName => [$filter, 'apply'],
+		];
+	}
+
+}

--- a/tests/Cases/ParsedownExtension.phpt
+++ b/tests/Cases/ParsedownExtension.phpt
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Parsedown\ParsedownExtension;
+use Contributte\Tester\Toolkit;
+use Latte\Engine;
+use Latte\Loaders\StringLoader;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$latte = new Engine();
+	$latte->addExtension(new ParsedownExtension());
+	$latte->setLoader(new StringLoader());
+
+	$text = <<<'LATTE'
+{block|parsedown}
+# Headline
+
+## Headline2
+{/block}
+LATTE;
+
+	Assert::equal("<h1>Headline</h1>\n<h2>Headline2</h2>", trim($latte->renderToString($text)));
+});
+
+Toolkit::test(function (): void {
+	$latte = new Engine();
+	$latte->addExtension(new ParsedownExtension(filterName: 'markdown'));
+	$latte->setLoader(new StringLoader());
+
+	$text = <<<'LATTE'
+{block|markdown}
+# Custom Filter Name
+{/block}
+LATTE;
+
+	Assert::equal('<h1>Custom Filter Name</h1>', trim($latte->renderToString($text)));
+});


### PR DESCRIPTION
- Add ParsedownExtension class for direct Latte usage without Nette DI
- Add test for standalone mode
- Update documentation with standalone usage examples
- Fix PHP 8.4 deprecation warnings in tests

Closes #22