### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `-p phpdbg` with `-p php` in the `coverage` target so coverage runs use the standard PHP binary.

## Motivation

Issue #73 tracks removing `phpdbg` from Contributte coverage targets. This repository still used `phpdbg` in `Makefile`.

## Changes

- switch the GitHub Actions coverage command from `phpdbg` to `php`
- switch the local coverage command from `phpdbg` to `php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification attempted
- `make coverage` currently fails in this environment because PHP has no Xdebug or PCOV extension available when running `php`
