### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed
- Added `secrets: inherit` to `.github/workflows/coverage.yml` so the reusable coverage workflow receives required secrets from callers.

## Why
- This completes the issue 74 rollout for this repository and keeps the coverage workflow compatible with the shared reusable workflow expectations in contributte/contributte#74.